### PR TITLE
Adds support for Making History fuel tanks

### DIFF
--- a/RealFuels/SquadExpansion_modularFuelTanks.cfg
+++ b/RealFuels/SquadExpansion_modularFuelTanks.cfg
@@ -1,0 +1,171 @@
+
+@PART[Size1p5_Tank_01]:FOR[RealFuels]
+{
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 1100
+		type = Default
+	}
+}
+
+@PART[Size1p5_Tank_02]:FOR[RealFuels]
+{
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 2200
+		type = Default
+	}
+}
+
+@PART[Size1p5_Tank_03]:FOR[RealFuels]
+{
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 4500
+		type = Default
+	}
+}
+
+@PART[Size1p5_Tank_04]:FOR[RealFuels]
+{
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 9000
+		type = Default
+	}
+}
+
+@PART[Size1p5_Tank_05]:FOR[RealFuels]
+{
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 6000
+		type = Default
+	}
+}
+
+@PART[MonoPropMini]:FOR[RealFuels]
+{
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 25
+		type = Default
+	}
+}
+
+@PART[Size1p5_Monoprop]:FOR[RealFuels]
+{
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 2500
+		type = Default
+	}
+}
+
+@PART[Size4_Tank_01]:FOR[RealFuels]
+{
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 32000
+		type = Default
+	}
+}
+
+@PART[Size4_Tank_02]:FOR[RealFuels]
+{
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 64000
+		type = Default
+	}
+}
+
+@PART[Size4_Tank_03]:FOR[RealFuels]
+{
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 128000
+		type = Default
+	}
+}
+
+@PART[Size4_Tank_04]:FOR[RealFuels]
+{
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 256000
+		type = Default
+	}
+}
+
+@PART[Size1p5_Size0_Adapter_01]:FOR[RealFuels]
+{
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 800
+		type = Default
+	}
+}
+
+@PART[Size1p5_Size1_Adapter_01]:FOR[RealFuels]
+{
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 3000
+		type = Default
+	}
+}
+
+@PART[Size1p5_Size1_Adapter_02]:FOR[RealFuels]
+{
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 800
+		type = Default
+	}
+}
+
+@PART[Size1p5_Size2_Adapter_01]:FOR[RealFuels]
+{
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 6000
+		type = Default
+	}
+}
+
+@PART[Size3_Size4_Adapter_01]:FOR[RealFuels]
+{
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 32000
+		type = Default
+	}
+}
+
+@PART[Size4_EngineAdapter_01]:FOR[RealFuels]
+{
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 45000
+		type = Default
+	}
+}
+


### PR DESCRIPTION
Added config that makes Making History Fuel Tanks usable in RO , the volumes were missing they have been calculated .