### PR TITLE
Expose propellantStability directly without rounding

### DIFF
--- a/Source/Engines/ModuleEnginesRF.cs
+++ b/Source/Engines/ModuleEnginesRF.cs
@@ -685,9 +685,8 @@ namespace RealFuels
                 {
                     if (EngineIgnited && ignited && throttledUp && rfSolver.GetRunning())
                     {
-                        double state = ullageSet.GetUllageProbability();
-                        double testValue = Math.Pow(state, RFSettings.Instance.stabilityPower);
-                        if (staticRandom.NextDouble() > testValue)
+                        double ullageProbability = ullageSet.GetUllageProbability();
+                        if (staticRandom.NextDouble() > ullageProbability)
                         {
                             ScreenMessages.PostScreenMessage(ullageFail);
                             FlightLogger.fetch.LogEvent($"[{FormatTime(vessel.missionTime)}] {ullageFail.message}");

--- a/Source/Engines/ModuleEnginesRF.cs
+++ b/Source/Engines/ModuleEnginesRF.cs
@@ -54,7 +54,7 @@ namespace RealFuels
 
         protected Propellant curveProp;
 
-        [KSPField(guiName = "#RF_EngineRF_IgnitedFor", guiUnits = "s", guiFormat = "F3", groupName = groupName)] // Ignited for 
+        [KSPField(guiName = "#RF_EngineRF_IgnitedFor", guiUnits = "s", guiFormat = "F3", groupName = groupName)] // Ignited for
         public float curveTime = 0f;
         #endregion
 
@@ -496,9 +496,9 @@ namespace RealFuels
                 tags += pressureFed ? ", " : string.Empty;
                 tags += $"<color=yellow>{Localizer.GetStringByTag("#RF_EngineRF_Ullage")}</color>"; // Ullage
             }
-            sISP = $"{atmosphereCurve.Evaluate(1):N0} (ASL) - {atmosphereCurve.Evaluate(0):N0} (Vac)"; // 
+            sISP = $"{atmosphereCurve.Evaluate(1):N0} (ASL) - {atmosphereCurve.Evaluate(0):N0} (Vac)"; //
             GetThrustData(out double thrustVac, out double thrustASL);
-            sThrust = $"{Utilities.FormatThrust(thrustASL)} (ASL) - {Utilities.FormatThrust(thrustVac)} (Vac)"; // 
+            sThrust = $"{Utilities.FormatThrust(thrustASL)} (ASL) - {Utilities.FormatThrust(thrustVac)} (Vac)"; //
             if (ignitions > 0)
                 sIgnitions = $"{ignitions:N0}";
             else if (ignitions == -1)
@@ -685,7 +685,7 @@ namespace RealFuels
                 {
                     if (EngineIgnited && ignited && throttledUp && rfSolver.GetRunning())
                     {
-                        double state = ullageSet.GetUllageStability();
+                        double state = ullageSet.GetUllageProbability();
                         double testValue = Math.Pow(state, RFSettings.Instance.stabilityPower);
                         if (staticRandom.NextDouble() > testValue)
                         {
@@ -762,10 +762,10 @@ namespace RealFuels
         #region Info
         protected string ThrottleString()
         {
-            if (throttleLocked) { return ", throttle locked"; } // 
-            if (MinThrottle == 1f) { return ", unthrottleable"; } // 
+            if (throttleLocked) { return ", throttle locked"; } //
+            if (MinThrottle == 1f) { return ", unthrottleable"; } //
             if (MinThrottle < 0f || MinThrottle > 1f) { return string.Empty; }
-            return $", {MinThrottle:P0} min throttle"; // 
+            return $", {MinThrottle:P0} min throttle"; //
         }
 
         protected void GetThrustData(out double thrustVac, out double thrustASL)
@@ -850,8 +850,8 @@ namespace RealFuels
                     output += $"{MinThrottle:P0} {Localizer.GetStringByTag("#RF_EngineRF_MinThrottle")}\n"; // min throttle
                     if (thrustASL != thrustVac)
                     {
-                        output += $"<b>{Localizer.GetStringByTag("#RF_EngineRF_MAXThrustInVac")}: </b>{Utilities.FormatThrust(thrustVac)} (TWR {thrustVac / weight:0.0##})\n"; //Max. Thrust (Vac) 
-                        output += $"<b>{Localizer.GetStringByTag("#RF_EngineRF_MAXThrustInASL")}: </b>{Utilities.FormatThrust(thrustASL)} (TWR {thrustASL / weight:0.0##})\n"; //Max. Thrust (ASL) 
+                        output += $"<b>{Localizer.GetStringByTag("#RF_EngineRF_MAXThrustInVac")}: </b>{Utilities.FormatThrust(thrustVac)} (TWR {thrustVac / weight:0.0##})\n"; //Max. Thrust (Vac)
+                        output += $"<b>{Localizer.GetStringByTag("#RF_EngineRF_MAXThrustInASL")}: </b>{Utilities.FormatThrust(thrustASL)} (TWR {thrustASL / weight:0.0##})\n"; //Max. Thrust (ASL)
                         output += $"<b>{Localizer.GetStringByTag("#RF_EngineRF_MINThrustInVac")}: </b>{Utilities.FormatThrust(thrustVac * MinThrottle)} (TWR {thrustVac * MinThrottle / weight:0.0##})\n"; // Min. Thrust (Vac)
                         output += $"<b>{Localizer.GetStringByTag("#RF_EngineRF_MINThrustInASL")}: </b>{Utilities.FormatThrust(thrustASL * MinThrottle)} (TWR {thrustASL * MinThrottle / weight:0.0##})\n"; // Min. Thrust (ASL)
                     }
@@ -887,7 +887,7 @@ namespace RealFuels
             return output;
         }
 
-        
+
         public override string GetInfo()
         {
             string output = $"{GetThrustInfo()}" +

--- a/Source/Ullage/UllageSet.cs
+++ b/Source/Ullage/UllageSet.cs
@@ -119,7 +119,7 @@ namespace RealFuels.Ullage
                 angularVelocity = engine.transform.InverseTransformDirection(engine.part.rb.angularVelocity);
             else
                 angularVelocity = engine.transform.InverseTransformDirection(angVel);
-            
+
             fuelRatio = 1d;
             if(HighLogic.LoadedSceneIsFlight && engine.EngineIgnited)
             {
@@ -139,6 +139,7 @@ namespace RealFuels.Ullage
         public void SetUllageStability(double newStability) => ullageSim.SetPropellantStability(newStability);
         public string GetUllageState(out Color col) => ullageSim.GetPropellantStatus(out col);
         public double GetUllageStability() => ullageSim.GetPropellantStability();
+        public double GetUllageProbability() => ullageSim.GetPropellantProbability();
         public bool PressureOK() => !engine.pressureFed || tanksHighlyPressurized;
         public bool EditorPressurized()
         {

--- a/Source/Ullage/UllageSimulator.cs
+++ b/Source/Ullage/UllageSimulator.cs
@@ -105,7 +105,7 @@ namespace RealFuels.Ullage
 
             //if (ventingAcc != 0.0f) Debug.Log("BoilOffAcc: " + ventingAcc.ToString("F8"));
             //else Debug.Log("BoilOffAcc: No boiloff.");
-            
+
             Vector3d localAccelerationAmount = localAcceleration * deltaTime;
             Vector3d rotationAmount = rotation * deltaTime;
 
@@ -179,8 +179,6 @@ namespace RealFuels.Ullage
             //Debug.Log("Ullage: pHorizontal: " + pHorizontal.ToString("F3"));
 
             propellantStability = Math.Max(0.0d, 1.0d - (pVertical * pHorizontal * (0.75d + Math.Sqrt(bLevel))));
-            if (propellantStability >= veryStable)
-                propellantStability = 1d;
 
 //#if DEBUG
 //            if (propellantStability < 0.5d)
@@ -204,9 +202,13 @@ namespace RealFuels.Ullage
                 propellantStatus = Localizer.GetStringByTag("#RF_UllageState_Unstable"); // "Unstable"
             else
                 propellantStatus = Localizer.GetStringByTag("#RF_UllageState_VeryUnstable"); // "Very Unstable"
-            propellantStatus += $" ({propellantStability:P2})";
+            propellantStatus += $" ({GetPropellantProbability():P2})";
         }
         public double GetPropellantStability() => propellantStability;
+        public double GetPropellantProbability()
+        {
+            return propellantStability >= veryStable ? 1.0d : propellantStability;
+        }
         public void SetPropellantStability(double newStab) => propellantStability = newStab;
         public string GetPropellantStatus(out Color col)
         {

--- a/Source/Ullage/UllageSimulator.cs
+++ b/Source/Ullage/UllageSimulator.cs
@@ -207,7 +207,9 @@ namespace RealFuels.Ullage
         public double GetPropellantStability() => propellantStability;
         public double GetPropellantProbability()
         {
-            return propellantStability >= veryStable ? 1.0d : propellantStability;
+            // round up veryStable (>= 0.996) to 100% stable
+            double stability = propellantStability >= veryStable ? 1.0d : propellantStability;
+            return Math.Pow(stability, RFSettings.Instance.stabilityPower);
         }
         public void SetPropellantStability(double newStab) => propellantStability = newStab;
         public string GetPropellantStatus(out Color col)


### PR DESCRIPTION
Introduces GetPropellantProbability/GetUllageProbability to get the rounded version that forces veryStable to 100% (couldn't think of a better name, even though this isn't really the proper probability since the exponent isn't applied).

This lets MJ 'see' values between 0.996 and 1.0

Didn't get this compiling yet because of all the RF deps and ROUtils in particular so be a little careful before merging.