### PR TITLE
Always recalculate seed in prelaunch

### DIFF
--- a/Source/Engines/ModuleEnginesRF.cs
+++ b/Source/Engines/ModuleEnginesRF.cs
@@ -424,7 +424,8 @@ namespace RealFuels
             }
             else
             {
-                if (partSeed == -1)
+                // Revert To Launch will use a state that is captured after the random got seeded
+                if (partSeed == -1 || vessel?.situation == Vessel.Situations.PRELAUNCH)
                 {
                     // using egg's formula here that ensures a gradual climb from 0, 0.5 as median (e^(0-ln(2)) == 0.5), and a very thin tail past 1.0
                     // Due to the exponent, this will never go below 0 so we needn't chop off variance in that direction.


### PR DESCRIPTION
Problem is that Revert To Launch will use a state that is captured after the random got seeded. This means that all reverts get the exact same engine performance. This in turn means that people may get overly confident in their design being able to cope with thrust offsets and having the performance needed.