### PR TITLE
Scale resources when B9PS changes the volume

### DIFF
--- a/Source/Tanks/ModuleFuelTanks.cs
+++ b/Source/Tanks/ModuleFuelTanks.cs
@@ -635,16 +635,9 @@ namespace RealFuels.Tanks
 
             // 'volume = x' provided
             var oldVolume = volume;
-            if (MFTConfigNode.TryGetValue("volume", ref volume))
+            if (MFTConfigNode.TryGetValue("volume", ref volume) && oldVolume != 0)
             {
-                if (volume == 0)
-                {
-                    Empty();
-                }
-                else if (oldVolume != 0)
-                {
-                    ChangeResources(volume / oldVolume);
-                }
+                ChangeResources(volume / oldVolume);
             }
 
             // 'basemass = x' provided

--- a/Source/Tanks/ModuleFuelTanks.cs
+++ b/Source/Tanks/ModuleFuelTanks.cs
@@ -634,7 +634,18 @@ namespace RealFuels.Tanks
             UpdateTypesAvailable(types);
 
             // 'volume = x' provided
-            MFTConfigNode.TryGetValue("volume", ref volume);
+            var oldVolume = volume;
+            if (MFTConfigNode.TryGetValue("volume", ref volume))
+            {
+                if (volume == 0)
+                {
+                    Empty();
+                }
+                else if (oldVolume != 0)
+                {
+                    ChangeResources(volume / oldVolume);
+                }
+            }
 
             // 'basemass = x' provided
             ParseBaseMass(MFTConfigNode);


### PR DESCRIPTION
This makes it so resources on a tank are scaled according to the new volume set in a B9PS patch.

Currently the volume is simply set without doing anything to the resources present.
This can lead to negative available volume, and is not how other mods that scale the volume behaves (ProcParts, ROTanks)
