### PR TITLE
Fix RCS tank types

### DIFF
--- a/RealFuels/SquadExpansion_modularFuelTanks.cfg
+++ b/RealFuels/SquadExpansion_modularFuelTanks.cfg
@@ -55,7 +55,7 @@
 	{
 		name = ModuleFuelTanks
 		volume = 25
-		type = Default
+		type = RCS
 	}
 }
 
@@ -65,7 +65,7 @@
 	{
 		name = ModuleFuelTanks
 		volume = 2500
-		type = Default
+		type = RCS
 	}
 }
 


### PR DESCRIPTION
Already correctly configured in https://github.com/KSP-RO/RealFuels/blob/de4ad0ca047631d9d88d882d968a6897187ccb52/ModularFuelTanks/Squad_MakingHistory.cfg (why are there 2? idek)

Fix https://github.com/KSP-RO/RealFuels/issues/344

Size1p5_Monoprop = https://wiki.kerbalspaceprogram.com/wiki/FL-R400_RCS_Fuel_Tank/Box
MonoPropMini = https://wiki.kerbalspaceprogram.com/wiki/Stratus-V_Minified_Monopropellant_Tank